### PR TITLE
Create docker specs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+Dockerfile*
+.dockerignore
+.git
+.gitignore
+dist
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Node.js runtime as the base image
+FROM node:14
+
+# Set the working directory inside the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json (if available)
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Start the application
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: sciscope_db
+      DB_USER: postgres
+      DB_PASSWORD: password
+    depends_on:
+      - db
+  db:
+    image: postgres:12
+    restart: always
+    environment:
+      POSTGRES_DB: sciscope_db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "dev": "nodemon index.js",
+    "start": "node app.js",
+    "dev": "nodemon app.js",
     "test": "jest",
     "clean": "rimraf dist",
     "build": "npm-run-all clean",
     "migrate-make": "knex migrate:make init --knexfile ./src/config/knexfile.js",
-    "migrate": "knex migrate:latest --knexfile ./src/config/knexfile.js"
+    "migrate": "knex migrate:latest --knexfile ./src/config/knexfile.js",
+    "docker:up": "docker-compose up --build",
+    "docker:down": "docker-compose down"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This PR introduces **Docker support** for SciScope, allowing the application to run in a containerized environment. The changes include:

- **Dockerfile:**  
  - Sets up a Node.js container.
  - Installs dependencies and defines the application entry point.
  - Exposes port 3000 for external access.

- **docker-compose.yml:**  
  - Orchestrates multi-container setup for the app and PostgreSQL.
  - Ensures the database is available before starting the application.
  - Uses environment variables for database configuration.

- **.dockerignore:**  
  - Excludes unnecessary files (e.g., `node_modules`, `.env`, `.git`) from being copied into the container, improving build efficiency.

- **Updated NPM Scripts:**  
  - Added `docker:up` (`docker-compose up --build`) to start the application in a Docker container.
  - Added `docker:down` (`docker-compose down`) to stop and remove running containers.

