### PR TITLE
35 add pagination to news api apiv1news

### DIFF
--- a/src/controllers/newsController.js
+++ b/src/controllers/newsController.js
@@ -8,8 +8,12 @@ import newsService from '../services/newsService.js';
  */
 export async function getScienceNews(req, res) {
   try {
-    const news = await newsService.processNewsRequest();
-    res.status(200).json(news);
+    const { page = 1, limit = 10 } = req.query;
+    const paginatedNews = await newsService.processNewsRequest(
+      Number(page),
+      Number(limit)
+    );
+    res.status(200).json(paginatedNews);
   } catch (error) {
     logger.error(`❌ Error fetching science news: ${error.message}`, {
       stack: error.stack,

--- a/tests/integration/routes/api/newsPagination.test.js
+++ b/tests/integration/routes/api/newsPagination.test.js
@@ -1,0 +1,134 @@
+import request from 'supertest';
+import db from '../../../../src/config/db.js';
+import createServer from '../../../../src/loaders/server.js';
+import { storeArticlesInDB } from '../../../../src/services/dbService.js';
+import { generateMockArticlesResponse } from '../../../mocks/generateMockArticles.js';
+
+const app = createServer();
+let server;
+
+beforeAll(() => {
+  server = app.listen(8080);
+});
+
+beforeEach(async () => {
+  await db('articles').del();
+});
+
+afterAll(async () => {
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+    console.log('Server closed.');
+  }
+
+  await db('articles').del();
+  await db.destroy();
+});
+
+describe('GET /api/v1/news Pagination', () => {
+  it('should return paginated news articles (page 1, limit 5)', async () => {
+    const mockRecentArticles = generateMockArticlesResponse(
+      15,
+      null,
+      true,
+      false,
+      3 // Ensures articles are within the last 3 hours
+    );
+
+    storeArticlesInDB(mockRecentArticles);
+
+    const res = await request(app).get('/api/v1/news?page=1&limit=5');
+
+    expect(res.status).toBe(200);
+    expect(res.body.total_count).toBe(15); // Mocked total count
+    expect(res.body.total_pages).toBe(3);
+    expect(res.body.current_page).toBe(1);
+    expect(res.body.articles.length).toBe(5);
+  });
+
+  it('should return the second page of news articles', async () => {
+    const mockRecentArticles = generateMockArticlesResponse(
+      20,
+      null,
+      true,
+      false,
+      3
+    );
+
+    storeArticlesInDB(mockRecentArticles);
+
+    const res = await request(app).get('/api/v1/news?page=2&limit=5');
+
+    expect(res.status).toBe(200);
+    expect(res.body.current_page).toBe(2);
+    expect(res.body.articles.length).toBe(5);
+  });
+
+  it('should return an empty array if page exceeds total articles', async () => {
+    const mockRecentArticles = generateMockArticlesResponse(
+      15,
+      null,
+      true,
+      false,
+      3
+    );
+
+    storeArticlesInDB(mockRecentArticles);
+
+    const res = await request(app).get('/api/v1/news?page=999&limit=5');
+
+    expect(res.status).toBe(200);
+    expect(res.body.articles).toEqual([]);
+    expect(res.body.articles.length).toBe(0);
+  });
+
+  it('should default to page 1 and limit 10 if no query params are provided', async () => {
+    const mockRecentArticles = generateMockArticlesResponse(
+      15,
+      null,
+      true,
+      false,
+      3
+    );
+
+    storeArticlesInDB(mockRecentArticles);
+
+    const res = await request(app).get('/api/v1/news');
+
+    expect(res.status).toBe(200);
+    expect(res.body.current_page).toBe(1);
+    expect(res.body.articles.length).toBeLessThanOrEqual(10);
+  });
+
+  it('should sort news articles by published_at DESC (latest first)', async () => {
+    const now = new Date();
+    const mockRecentArticles = generateMockArticlesResponse(
+      15,
+      null,
+      true,
+      false,
+      3
+    );
+
+    storeArticlesInDB(mockRecentArticles);
+
+    const res = await request(app).get('/api/v1/news?page=1&limit=5');
+
+    expect(res.status).toBe(200);
+    const { articles } = res.body;
+
+    expect(articles.length).toBeGreaterThan(1);
+    expect(new Date(articles[0].publishedAt)).toBeInstanceOf(Date);
+    expect(
+      new Date(articles[0].publishedAt) >=
+        new Date(articles[articles.length - 1].publishedAt)
+    ).toBe(true);
+
+    // Ensure all articles are within the last 3 hours
+    articles.forEach((article) => {
+      expect(new Date(article.publishedAt).getTime()).toBeGreaterThanOrEqual(
+        now - 3 * 60 * 60 * 1000
+      );
+    });
+  });
+});

--- a/tests/integration/routes/api/searchPagination.test.js
+++ b/tests/integration/routes/api/searchPagination.test.js
@@ -11,11 +11,6 @@ beforeAll(async () => {
   await knex.seed.run();
 });
 
-beforeEach(async () => {
-  // await knex.migrate.latest();
-  // await knex.seed.run();
-});
-
 afterAll(async () => {
   if (server) {
     await new Promise((resolve) => server.close(resolve));

--- a/tests/integration/routes/api/searchRoutes.test.js
+++ b/tests/integration/routes/api/searchRoutes.test.js
@@ -8,7 +8,7 @@ const app = createServer();
 let server;
 
 beforeAll(() => {
-  server = app.listen(3030);
+  server = app.listen(8080);
 });
 
 beforeEach(async () => {
@@ -18,7 +18,7 @@ beforeEach(async () => {
 afterAll(async () => {
   if (server) {
     await new Promise((resolve) => server.close(resolve));
-    console.log('✅ Server closed.');
+    console.log('Server closed.');
   }
 
   await db('articles').del();


### PR DESCRIPTION
# 🚀 Add Pagination to News API

## **Summary**
This PR implements pagination for the **News API (`/api/v1/news`)**, ensuring efficient navigation through large datasets. It also updates relevant tests to reflect these changes.

## **Changes Introduced**
✅ Added **page** and **limit** query parameters to `/api/v1/news`.  
✅ Implemented pagination in **`processNewsRequest`**.  
✅ Ensured API fetch respects pagination constraints.  
✅ Updated **`fetchRecentArticles`** to support in-memory pagination.  
✅ Added **integration tests** for paginated news responses.  
✅ Refactored and cleaned up existing tests.  

## **Test Coverage**
- 🧪 **Integration Tests** added for **news pagination**.
- 🧪 **Refactored unit tests** to match the updated response structure.
- ✅ All tests passing locally and in GitHub Actions.

