### PR TITLE
41 1 setup basic caching service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "morgan": "^1.10.0",
+        "node-cache": "^5.1.2",
         "objection": "^3.1.5",
         "passport": "^0.7.0",
         "passport-github2": "^0.1.12",
@@ -4556,6 +4557,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -9710,6 +9720,18 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "license": "MIT"
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "morgan": "^1.10.0",
+    "node-cache": "^5.1.2",
     "objection": "^3.1.5",
     "passport": "^0.7.0",
     "passport-github2": "^0.1.12",

--- a/src/services/cacheService.js
+++ b/src/services/cacheService.js
@@ -1,0 +1,64 @@
+import NodeCache from 'node-cache';
+import logger from '../loaders/logger.js';
+
+// ⚡ Set up cache with 1-hour TTL (3600 seconds)
+const cache = new NodeCache({ stdTTL: 3600, checkperiod: 300 });
+
+/**
+ * Store a value in cache
+ * @param {string} key - The cache key
+ * @param {any} value - The value to store
+ * @param {number} [ttl] - Optional custom TTL in seconds
+ */
+export const setCache = (key, value, ttl = 900) => {
+  const success = cache.set(key, value, ttl);
+  if (success) logger.info(`🟢 Cached: ${key} (TTL: ${ttl}s)`);
+  return success;
+};
+
+/**
+ * Retrieve a value from cache
+ * @param {string} key - The cache key
+ * @returns {any|null} - Cached value or null if not found
+ */
+export const getCache = (key) => {
+  const value = cache.get(key);
+  if (value) {
+    logger.info(`⚡ Cache Hit: ${key}`);
+    return value;
+  }
+  logger.info(`❌ Cache Miss: ${key}`);
+  return null;
+};
+
+/**
+ * Remove a specific key from cache
+ * @param {string} key - The cache key
+ */
+export const delCache = (key) => {
+  const success = cache.del(key);
+  if (success) logger.info(`🗑️ Cache Deleted: ${key}`);
+};
+
+/**
+ * Flush all cache entries
+ */
+export const flushCache = () => {
+  cache.flushAll();
+  logger.info('🗑️ Cache Fully Cleared');
+};
+
+/**
+ * Get cache stats for debugging
+ */
+export const getCacheStats = () => {
+  return cache.getStats();
+};
+
+export default {
+  setCache,
+  getCache,
+  delCache,
+  flushCache,
+  getCacheStats,
+};

--- a/tests/unit/services/cacheService.test.js
+++ b/tests/unit/services/cacheService.test.js
@@ -1,0 +1,56 @@
+import { jest } from '@jest/globals';
+import db from '../../../src/config/db.js';
+import logger from '../../../src/loaders/logger.js';
+import {
+  delCache,
+  flushCache,
+  getCache,
+  setCache,
+} from '../../../src/services/cacheService.js';
+
+afterAll(async () => {
+  await db.destroy();
+});
+
+describe('CacheService', () => {
+  beforeEach(() => {
+    flushCache(); // Ensure clean state for each test
+    jest.clearAllMocks(); // Reset mocks before each test
+  });
+
+  it('should store and retrieve a cached value', () => {
+    setCache('testKey', 'testValue', 600);
+    const value = getCache('testKey');
+    expect(value).toBe('testValue');
+  });
+
+  it('should return null for expired or missing keys', async () => {
+    setCache('expiredKey', 'someValue', 1);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    expect(getCache('expiredKey')).toBeNull();
+    expect(getCache('nonExistentKey')).toBeNull();
+  });
+
+  it('should delete a key from cache', () => {
+    setCache('keyToDelete', 'deleteMe', 600);
+    delCache('keyToDelete');
+    expect(getCache('keyToDelete')).toBeNull();
+  });
+
+  it('should log when fetching from cache vs. making a fresh call', () => {
+    const spy = jest.spyOn(logger, 'info').mockImplementation(() => {}); // ✅ Mock logger
+
+    setCache('logKey', 'logValue', 600);
+    getCache('logKey'); // Should log cache hit
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('⚡ Cache Hit: logKey')
+    );
+
+    getCache('missKey'); // Should log cache miss
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('❌ Cache Miss: missKey')
+    );
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## 🚀 chore: Add Node-Cache & Implement Basic Caching Service  

### **📌 Summary**  
This PR introduces **in-memory caching** using `node-cache` to improve performance by reducing redundant API calls for fetching science news.  

### **✨ What's New?**  
✅ **Installed `node-cache`** for efficient caching.  
✅ **Created `cacheService.js`** to handle:  
   - `setCache(key, value, ttl)` - Stores data with a TTL.  
   - `getCache(key)` - Retrieves cached data or logs a cache miss.  
   - `delCache(key)` - Deletes a specific cache entry.  
   - `flushCache()` - Clears all cached data.  
   - `getCacheStats()` - Provides cache stats for debugging.  
✅ **Configured a 1-hour TTL** for cache expiration.  
✅ **Added logging** to track cache hits/misses.  

### **🧪 Tests Added**  
🔹 **Unit tests for `CacheService.js`**:  
   - Stores & retrieves cached values.  
   - Handles expired/missing keys correctly.  
   - Deletes cache entries.  
   - Logs cache hits/misses properly.  