### PR TITLE
feat: Add disableApiFallback param to prevent real API calls in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:all": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --verbose --bail=0 --coverage --detectOpenHandles",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:real": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --detectOpenHandles --verbose --bail=0 tests/integration/realApi/",
+    "test:quick": "SKIP_DB_RESET=true NODE_OPTIONS=--experimental-vm-modules jest --runInBand --verbose --bail=0 --testPathIgnorePatterns=realApi --detectOpenHandles",
     "lint": "eslint .",
     "format": "prettier --write .",
     "migrate-make": "knex migrate:make $(date +%Y%m%d_%H%M%S)_migration --knexfile src/config/knexfile.js",

--- a/src/controllers/analyticsController.js
+++ b/src/controllers/analyticsController.js
@@ -1,0 +1,38 @@
+import logger from '../loaders/logger.js';
+import analyticsService from '../services/analyticsService.js';
+
+async function handleAnalyticsRequest(serviceMethod, label, req, res) {
+  try {
+    const page = Number(req.query.page) || 1;
+    const limit = Number(req.query.limit) || 10;
+
+    const results = await serviceMethod(page, limit);
+
+    res.status(200).json({ results, page, limit });
+  } catch (error) {
+    logger.error(`❌ Error fetching ${label}: ${error.message}`, {
+      stack: error.stack,
+    });
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export async function mostBookmarkedArticles(req, res) {
+  return handleAnalyticsRequest(
+    analyticsService.getMostBookmarkedArticles,
+    'Most Bookmarked Articles',
+    req,
+    res
+  );
+}
+
+export async function topBookmarkingUsers(req, res) {
+  return handleAnalyticsRequest(
+    analyticsService.getTopBookmarkingUsers,
+    'Top Bookmarking Users',
+    req,
+    res
+  );
+}
+
+export default { mostBookmarkedArticles, topBookmarkingUsers };

--- a/src/controllers/newsController.js
+++ b/src/controllers/newsController.js
@@ -8,11 +8,17 @@ import newsService from '../services/newsService.js';
  */
 export async function getScienceNews(req, res) {
   try {
-    const { page = 1, limit = 10 } = req.query;
+    const { page = 1, limit = 10, test_no_api } = req.query;
+
+    // Only used in test environments to prevent real API calls
+    const disableApiFallback = test_no_api === 'true';
+
     const paginatedNews = await newsService.processNewsRequest(
       Number(page),
-      Number(limit)
+      Number(limit),
+      disableApiFallback // pass test parmas the service
     );
+
     res.status(200).json(paginatedNews);
   } catch (error) {
     logger.error(`❌ Error fetching science news: ${error.message}`, {

--- a/src/routes/api/analyticsRoutes.js
+++ b/src/routes/api/analyticsRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import analyticsController from '../../controllers/analyticsController.js';
+
+const router = express.Router();
+
+router.get(
+  '/most-bookmarked-articles',
+  analyticsController.mostBookmarkedArticles
+);
+router.get('/top-bookmarking-users', analyticsController.topBookmarkingUsers);
+
+export default router;

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -3,6 +3,7 @@ import searchRoutes from './searchRoutes.js';
 import authRoutes from './authRoutes.js';
 import bookmarkRoutes from './bookmarkRoutes.js';
 import newsRoutes from './newsRoutes.js';
+import analyticsRoutes from './analyticsRoutes.js';
 import protectedRoutes from './protectedRoutes.js';
 
 const router = express.Router();
@@ -12,5 +13,6 @@ router.use(protectedRoutes);
 router.use('/news', newsRoutes);
 router.use('/search', searchRoutes);
 router.use('/bookmarks', bookmarkRoutes);
+router.use('/analytics', analyticsRoutes);
 
 export default router;

--- a/src/services/cacheService.js
+++ b/src/services/cacheService.js
@@ -22,9 +22,7 @@ export const setCache = (key, value, ttl = 3600) => {
  * @returns {any|null} - Cached value or null if not found
  */
 export const getCache = (key) => {
-  // console.log('key:', key);
   const value = cache.get(key);
-  // console.log('value:', value);
   if (value) {
     logger.info(`⚡ Cache Hit: ${key}`);
     return value;

--- a/tests/globalTeardown.js
+++ b/tests/globalTeardown.js
@@ -2,13 +2,14 @@ import axios from 'axios';
 import db from '../src/config/db.js';
 
 export default async function globalTeardown() {
+  if (process.env.SKIP_DB_RESET === 'true') {
+    console.log('⚡️ Skipping global DB teardown...');
+    return;
+  }
+
   console.log('🔻 Running global teardown...');
-
   try {
-    // Cancel any pending axios requests
     axios.CancelToken.source().cancel('Test cleanup');
-
-    // Ensure database connections are fully closed
     await db.destroy();
     console.log('✅ Database connection closed.');
   } catch (error) {

--- a/tests/integration/routes/api/analyticsRoutes.test.js
+++ b/tests/integration/routes/api/analyticsRoutes.test.js
@@ -1,0 +1,179 @@
+import request from 'supertest';
+import createServer from '../../../../src/loaders/server.js';
+import db from '../../../../src/config/db.js';
+import cacheService from '../../../../src/services/cacheService.js';
+import { execSync } from 'child_process';
+
+const app = createServer();
+let server;
+
+// ✅ Use a clean, explicit flag for controlling seed behavior
+const shouldSeed = process.env.SKIP_DB_RESET !== 'true';
+
+const MOST_BOOKMARKED_CACHE_KEY = 'most_bookmarked_articles';
+const TOP_BOOKMARKING_USERS_CACHE_KEY = 'top_bookmarking_users';
+
+beforeAll(async () => {
+  server = app.listen(8080);
+
+  if (shouldSeed) {
+    console.log('🚀 Seeding large test database for analytics tests...');
+    execSync('NODE_ENV=test node scripts/resetAndSeedTestDatabase.js', {
+      stdio: 'inherit',
+    });
+  } else {
+    console.log('⚡️ Skipping DB seed (using previously seeded data)');
+  }
+});
+
+beforeEach(() => {
+  cacheService.flushCache();
+});
+
+afterAll(async () => {
+  const currentDb = await db.raw('SELECT current_database();');
+  console.log(
+    `🛑 Closing DB connection to: ${currentDb.rows[0].current_database}`
+  );
+  await db.destroy();
+
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+    console.log('✅ Server closed.');
+  }
+});
+
+describe('📊 GET /api/analytics/most-bookmarked', () => {
+  it('returns top bookmarked articles with correct structure and pagination', async () => {
+    const res = await request(app).get(
+      '/api/v1/analytics/most-bookmarked-articles?limit=5&page=1'
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('results');
+    expect(Array.isArray(res.body.results)).toBe(true);
+    expect(res.body.results.length).toBeLessThanOrEqual(5);
+
+    const first = res.body.results[0];
+    expect(first).toHaveProperty('article_id');
+    expect(first).toHaveProperty('title');
+    expect(first).toHaveProperty('bookmark_count');
+
+    // Ensure descending order
+    for (let i = 1; i < res.body.results.length; i++) {
+      expect(
+        Number(res.body.results[i - 1].bookmark_count)
+      ).toBeGreaterThanOrEqual(Number(res.body.results[i].bookmark_count));
+    }
+  });
+
+  it('uses cached results after first request', async () => {
+    const page = 1;
+    const limit = 3;
+    const offset = (page - 1) * limit;
+
+    // 🔹 First request populates the cache
+    const firstRes = await request(app).get(
+      `/api/v1/analytics/most-bookmarked-articles?limit=${limit}&page=${page}`
+    );
+    expect(firstRes.statusCode).toBe(200);
+
+    // 🔹 Check that the cache now exists and is full
+    const cached = cacheService.getCache(MOST_BOOKMARKED_CACHE_KEY);
+    expect(cached).toBeInstanceOf(Array);
+    expect(cached.length).toBeGreaterThan(limit);
+    expect(cached.length).toBeLessThanOrEqual(50);
+
+    // 🔹 First response should match the first page from cached results
+    const expectedSlice = cached.slice(offset, offset + limit);
+    expect(firstRes.body.results).toEqual(expectedSlice);
+
+    // 🔹 Second request should return the same slice
+    const secondRes = await request(app).get(
+      `/api/v1/analytics/most-bookmarked-articles?limit=${limit}&page=${page}`
+    );
+    expect(secondRes.statusCode).toBe(200);
+    expect(secondRes.body.results).toEqual(expectedSlice);
+  });
+
+  it('returns paginated results on different pages', async () => {
+    const res1 = await request(app).get(
+      '/api/v1/analytics/most-bookmarked-articles?page=1&limit=2'
+    );
+    const res2 = await request(app).get(
+      '/api/v1/analytics/most-bookmarked-articles?page=2&limit=2'
+    );
+    expect(res1.body.results.length).toBeGreaterThan(0);
+    expect(res2.body.results.length).toBeGreaterThan(0);
+    expect(res1.body.results[0].article_id).not.toEqual(
+      res2.body.results[0].article_id
+    );
+  });
+});
+
+describe('📊 GET /api/analytics/top-bookmarking-users', () => {
+  it('returns top users with correct structure and pagination', async () => {
+    const res = await request(app).get(
+      '/api/v1/analytics/top-bookmarking-users?limit=5&page=1'
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('results');
+    expect(Array.isArray(res.body.results)).toBe(true);
+    expect(res.body.results.length).toBeLessThanOrEqual(5);
+
+    const first = res.body.results[0];
+    expect(first).toHaveProperty('user_id');
+    expect(first).toHaveProperty('username');
+    expect(first).toHaveProperty('bookmark_count');
+
+    for (let i = 1; i < res.body.results.length; i++) {
+      expect(
+        Number(res.body.results[i - 1].bookmark_count)
+      ).toBeGreaterThanOrEqual(Number(res.body.results[i].bookmark_count));
+    }
+  });
+
+  it('uses cached results after first request', async () => {
+    const page = 1;
+    const limit = 3;
+    const offset = (page - 1) * limit;
+
+    // 🔹 First request populates the cache
+    const firstRes = await request(app).get(
+      `/api/v1/analytics/top-bookmarking-users?limit=${limit}&page=${page}`
+    );
+    expect(firstRes.statusCode).toBe(200);
+
+    // 🔹 Check that the cache now exists and is full
+    const cached = cacheService.getCache(TOP_BOOKMARKING_USERS_CACHE_KEY);
+    expect(cached).toBeInstanceOf(Array);
+    expect(cached.length).toBeGreaterThan(limit);
+    expect(cached.length).toBeLessThanOrEqual(50);
+
+    // 🔹 First response should match the first page from cached results
+    const expectedSlice = cached.slice(offset, offset + limit);
+    expect(firstRes.body.results).toEqual(expectedSlice);
+
+    // 🔹 Second request should return the same slice
+    const secondRes = await request(app).get(
+      `/api/v1/analytics/top-bookmarking-users?limit=${limit}&page=${page}`
+    );
+    expect(secondRes.statusCode).toBe(200);
+    expect(secondRes.body.results).toEqual(expectedSlice);
+  });
+
+  it('returns paginated results on different pages', async () => {
+    const res1 = await request(app).get(
+      '/api/v1/analytics/top-bookmarking-users?page=1&limit=2'
+    );
+    const res2 = await request(app).get(
+      '/api/v1/analytics/top-bookmarking-users?page=2&limit=2'
+    );
+    expect(res1.body.results.length).toBeGreaterThan(0);
+    expect(res2.body.results.length).toBeGreaterThan(0);
+    expect(res1.body.results[0].user_id).not.toEqual(
+      res2.body.results[0].user_id
+    );
+  });
+});

--- a/tests/integration/routes/api/articleSearchRoutes.test.js
+++ b/tests/integration/routes/api/articleSearchRoutes.test.js
@@ -13,10 +13,16 @@ beforeAll(() => {
   server = app.listen(8080);
 });
 
+beforeEach(async () => {
+  await db('articles').del();
+});
+
 afterAll(async () => {
   if (server) {
     await new Promise((resolve) => server.close(resolve));
+    console.log('✅ Server closed.');
   }
+
   await db('articles').del();
   await db.destroy();
 });

--- a/tests/integration/routes/api/bookmarkRoutes.test.js
+++ b/tests/integration/routes/api/bookmarkRoutes.test.js
@@ -9,7 +9,7 @@ const app = createServer();
 let server, token, user, article, article2;
 
 beforeAll(async () => {
-  server = app.listen(3031);
+  server = app.listen(8080);
   await knex.migrate.latest();
   await knex.seed.run();
 });

--- a/tests/integration/routes/api/newsPagination.test.js
+++ b/tests/integration/routes/api/newsPagination.test.js
@@ -78,7 +78,9 @@ describe('GET /api/v1/news Pagination', () => {
 
     await storeArticlesInDB(mockRecentArticles);
 
-    const res = await request(app).get('/api/v1/news?page=999&limit=5');
+    const res = await request(app).get(
+      '/api/v1/news?page=999&limit=5&test_no_api=true'
+    );
 
     expect(res.status).toBe(200);
     expect(res.body.articles).toEqual([]);

--- a/tests/integration/routes/api/searchRoutes.test.js
+++ b/tests/integration/routes/api/searchRoutes.test.js
@@ -18,9 +18,8 @@ beforeEach(async () => {
 afterAll(async () => {
   if (server) {
     await new Promise((resolve) => server.close(resolve));
-    console.log('Server closed.');
+    console.log('✅ Server closed.');
   }
-
   await db('articles').del();
   await db.destroy();
 });

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,15 +1,3 @@
 import { jest } from '@jest/globals';
-import dotenv from 'dotenv';
-import db from '../src/config/db.js';
-import logger from '../src/loaders/logger.js';
 
-dotenv.config();
-
-beforeAll(async () => {
-  logger.info('🧹 Clearing test data...');
-  await db('articles').del();
-  await db('user_bookmarks').del();
-  await db('bookmark_group_assignments').del();
-});
-
-jest.setTimeout(30000);
+jest.setTimeout(30000); // 30 seconds

--- a/tests/unit/services/analyticsService.test.js
+++ b/tests/unit/services/analyticsService.test.js
@@ -3,8 +3,8 @@ import analyticsService from '../../../src/services/analyticsService.js';
 import cacheService from '../../../src/services/cacheService.js';
 import { execSync } from 'child_process';
 
-const MOST_BOOKMARKED_CACHE_KEY = 'most_bookmarked_articles';
-const TOP_BOOKMARKING_USERS_CACHE_KEY = 'top_bookmarking_users';
+const MOST_BOOKMARKED_CACHE_KEY = 'most_bookmarked_articles_page1_limit5';
+const TOP_BOOKMARKING_USERS_CACHE_KEY = 'top_bookmarking_users_page1_limit5';
 
 beforeAll(async () => {
   console.log('🚀 Resetting and seeding the test database...');
@@ -28,74 +28,67 @@ describe('🔎 Bookmark Analytics Queries (with Caching)', () => {
 
   /** ✅ Most Bookmarked Articles Tests */
   it('should return the most bookmarked articles in descending order & cache the result', async () => {
-    const articles = await analyticsService.getMostBookmarkedArticles(5);
+    const articles = await analyticsService.getMostBookmarkedArticles(1, 5);
 
     expect(articles).toBeInstanceOf(Array);
     expect(articles.length).toBeGreaterThan(0);
 
-    // ✅ Ensure articles are sorted by bookmark count
     for (let i = 1; i < articles.length; i++) {
       expect(Number(articles[i - 1].bookmark_count)).toBeGreaterThanOrEqual(
         Number(articles[i].bookmark_count)
       );
     }
 
-    // ✅ Cache should now contain the result
     const cachedArticles = cacheService.getCache(MOST_BOOKMARKED_CACHE_KEY);
     expect(cachedArticles).toEqual(articles);
   });
 
   it('should return cached results for most bookmarked articles', async () => {
-    cacheService.setCache(
-      MOST_BOOKMARKED_CACHE_KEY,
-      [{ id: 1, title: 'Cached Article' }],
-      600
-    );
+    const mockData = [
+      { article_id: 1, title: 'Cached Article', bookmark_count: 99 },
+    ];
+    cacheService.setCache(MOST_BOOKMARKED_CACHE_KEY, mockData, 600);
 
-    const articles = await analyticsService.getMostBookmarkedArticles(5);
-    expect(articles).toEqual([{ id: 1, title: 'Cached Article' }]);
+    const articles = await analyticsService.getMostBookmarkedArticles(1, 5);
+    expect(articles).toEqual(mockData);
   });
 
   /** ✅ Top Bookmarking Users Tests */
   it('should return the top bookmarking users in descending order & cache the result', async () => {
-    const users = await analyticsService.getTopBookmarkingUsers(5);
+    const users = await analyticsService.getTopBookmarkingUsers(1, 5);
 
     expect(users).toBeInstanceOf(Array);
     expect(users.length).toBeGreaterThan(0);
 
-    // ✅ Ensure users are sorted by bookmark count
     for (let i = 1; i < users.length; i++) {
       expect(Number(users[i - 1].bookmark_count)).toBeGreaterThanOrEqual(
         Number(users[i].bookmark_count)
       );
     }
 
-    // ✅ Cache should now contain the result
     const cachedUsers = cacheService.getCache(TOP_BOOKMARKING_USERS_CACHE_KEY);
     expect(cachedUsers).toEqual(users);
   });
 
   it('should return cached results for top bookmarking users', async () => {
-    cacheService.setCache(
-      TOP_BOOKMARKING_USERS_CACHE_KEY,
-      [{ id: 2, username: 'Cached User' }],
-      600
-    );
+    const mockData = [
+      { user_id: 2, username: 'Cached User', bookmark_count: 42 },
+    ];
+    cacheService.setCache(TOP_BOOKMARKING_USERS_CACHE_KEY, mockData, 600);
 
-    const users = await analyticsService.getTopBookmarkingUsers(5);
-    expect(users).toEqual([{ id: 2, username: 'Cached User' }]);
+    const users = await analyticsService.getTopBookmarkingUsers(1, 5);
+    expect(users).toEqual(mockData);
   });
 
   /** ✅ Cache Expiration & Regeneration */
   it('should fetch fresh data after cache expires', async () => {
-    cacheService.setCache(
-      MOST_BOOKMARKED_CACHE_KEY,
-      [{ id: 3, title: 'Old Cached Article' }],
-      1
-    );
+    const oldData = [
+      { article_id: 3, title: 'Old Cached Article', bookmark_count: 1 },
+    ];
+    cacheService.setCache(MOST_BOOKMARKED_CACHE_KEY, oldData, 1);
     await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    const articles = await analyticsService.getMostBookmarkedArticles(5);
-    expect(articles).not.toEqual([{ id: 3, title: 'Old Cached Article' }]);
+    const articles = await analyticsService.getMostBookmarkedArticles(1, 5);
+    expect(articles).not.toEqual(oldData);
   });
 });

--- a/tests/unit/services/analyticsService.test.js
+++ b/tests/unit/services/analyticsService.test.js
@@ -1,24 +1,46 @@
-import knex from '../../../src/config/db.js';
+import createServer from '../../../src/loaders/server.js';
+import db from '../../../src/config/db.js';
 import analyticsService from '../../../src/services/analyticsService.js';
 import cacheService from '../../../src/services/cacheService.js';
 import { execSync } from 'child_process';
 
-const MOST_BOOKMARKED_CACHE_KEY = 'most_bookmarked_articles_page1_limit5';
-const TOP_BOOKMARKING_USERS_CACHE_KEY = 'top_bookmarking_users_page1_limit5';
+const app = createServer();
+let server;
+
+// ✅ Use a clean, explicit flag for controlling seed behavior
+const shouldSeed = process.env.SKIP_DB_RESET !== 'true';
+
+const MOST_BOOKMARKED_CACHE_KEY = 'most_bookmarked_articles';
+const TOP_BOOKMARKING_USERS_CACHE_KEY = 'top_bookmarking_users';
 
 beforeAll(async () => {
-  console.log('🚀 Resetting and seeding the test database...');
-  execSync('NODE_ENV=test node scripts/resetAndSeedTestDatabase.js', {
-    stdio: 'inherit',
-  });
+  server = app.listen(8080);
+
+  if (shouldSeed) {
+    console.log('🚀 Seeding large test database for analytics tests...');
+    execSync('NODE_ENV=test node scripts/resetAndSeedTestDatabase.js', {
+      stdio: 'inherit',
+    });
+  } else {
+    console.log('⚡️ Skipping DB seed (using previously seeded data)');
+  }
+});
+
+beforeEach(() => {
+  cacheService.flushCache();
 });
 
 afterAll(async () => {
-  const currentDb = await knex.raw('SELECT current_database();');
+  const currentDb = await db.raw('SELECT current_database();');
   console.log(
-    `🛑 Closing connection to: ${currentDb.rows[0].current_database}`
+    `🛑 Closing DB connection to: ${currentDb.rows[0].current_database}`
   );
-  await knex.destroy();
+  await db.destroy();
+
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+    console.log('✅ Server closed.');
+  }
 });
 
 describe('🔎 Bookmark Analytics Queries (with Caching)', () => {
@@ -27,38 +49,64 @@ describe('🔎 Bookmark Analytics Queries (with Caching)', () => {
   });
 
   /** ✅ Most Bookmarked Articles Tests */
-  it('should return the most bookmarked articles in descending order & cache the result', async () => {
-    const articles = await analyticsService.getMostBookmarkedArticles(1, 5);
+  it('should return paginated results & cache full set of top 50 articles', async () => {
+    const page = 1;
+    const limit = 5;
+    const offset = (page - 1) * limit;
+
+    const articles = await analyticsService.getMostBookmarkedArticles(
+      page,
+      limit
+    );
 
     expect(articles).toBeInstanceOf(Array);
-    expect(articles.length).toBeGreaterThan(0);
+    expect(articles.length).toBeLessThanOrEqual(limit);
 
+    // Ensure descending order
     for (let i = 1; i < articles.length; i++) {
       expect(Number(articles[i - 1].bookmark_count)).toBeGreaterThanOrEqual(
         Number(articles[i].bookmark_count)
       );
     }
 
-    const cachedArticles = cacheService.getCache(MOST_BOOKMARKED_CACHE_KEY);
-    expect(cachedArticles).toEqual(articles);
+    // ✅ Cached value should be the full top 50
+    const cached = cacheService.getCache(MOST_BOOKMARKED_CACHE_KEY);
+    expect(cached).toBeInstanceOf(Array);
+    expect(cached.length).toBeGreaterThanOrEqual(limit);
+
+    // ✅ Returned page should match the slice from cached data
+    const expectedSlice = cached.slice(offset, offset + limit);
+    expect(articles).toEqual(expectedSlice);
   });
 
-  it('should return cached results for most bookmarked articles', async () => {
-    const mockData = [
-      { article_id: 1, title: 'Cached Article', bookmark_count: 99 },
-    ];
+  it('should return cached results when already set', async () => {
+    const mockData = Array.from({ length: 50 }, (_, i) => ({
+      article_id: i + 1,
+      title: `Cached Article ${i + 1}`,
+      bookmark_count: 100 - i,
+    }));
     cacheService.setCache(MOST_BOOKMARKED_CACHE_KEY, mockData, 600);
 
-    const articles = await analyticsService.getMostBookmarkedArticles(1, 5);
-    expect(articles).toEqual(mockData);
+    const page = 1;
+    const limit = 5;
+    const result = await analyticsService.getMostBookmarkedArticles(
+      page,
+      limit
+    );
+    const expectedSlice = mockData.slice(0, limit);
+
+    expect(result).toEqual(expectedSlice);
   });
 
   /** ✅ Top Bookmarking Users Tests */
-  it('should return the top bookmarking users in descending order & cache the result', async () => {
-    const users = await analyticsService.getTopBookmarkingUsers(1, 5);
+  it('should return paginated top users & cache full top 50', async () => {
+    const page = 1;
+    const limit = 5;
+    const offset = (page - 1) * limit;
 
+    const users = await analyticsService.getTopBookmarkingUsers(page, limit);
     expect(users).toBeInstanceOf(Array);
-    expect(users.length).toBeGreaterThan(0);
+    expect(users.length).toBeLessThanOrEqual(limit);
 
     for (let i = 1; i < users.length; i++) {
       expect(Number(users[i - 1].bookmark_count)).toBeGreaterThanOrEqual(
@@ -66,29 +114,42 @@ describe('🔎 Bookmark Analytics Queries (with Caching)', () => {
       );
     }
 
-    const cachedUsers = cacheService.getCache(TOP_BOOKMARKING_USERS_CACHE_KEY);
-    expect(cachedUsers).toEqual(users);
+    const cached = cacheService.getCache(TOP_BOOKMARKING_USERS_CACHE_KEY);
+    expect(cached).toBeInstanceOf(Array);
+    expect(cached.length).toBeGreaterThanOrEqual(limit);
+
+    const expectedSlice = cached.slice(offset, offset + limit);
+    expect(users).toEqual(expectedSlice);
   });
 
-  it('should return cached results for top bookmarking users', async () => {
-    const mockData = [
-      { user_id: 2, username: 'Cached User', bookmark_count: 42 },
-    ];
-    cacheService.setCache(TOP_BOOKMARKING_USERS_CACHE_KEY, mockData, 600);
+  it('should return cached top users when already set', async () => {
+    const mockUsers = Array.from({ length: 50 }, (_, i) => ({
+      user_id: i + 1,
+      username: `User ${i + 1}`,
+      email: `user${i + 1}@example.com`,
+      bookmark_count: 50 - i,
+    }));
+    cacheService.setCache(TOP_BOOKMARKING_USERS_CACHE_KEY, mockUsers, 600);
 
-    const users = await analyticsService.getTopBookmarkingUsers(1, 5);
-    expect(users).toEqual(mockData);
+    const page = 2;
+    const limit = 10;
+    const expected = mockUsers.slice(10, 20);
+
+    const result = await analyticsService.getTopBookmarkingUsers(page, limit);
+    expect(result).toEqual(expected);
   });
 
   /** ✅ Cache Expiration & Regeneration */
   it('should fetch fresh data after cache expires', async () => {
-    const oldData = [
-      { article_id: 3, title: 'Old Cached Article', bookmark_count: 1 },
-    ];
+    const oldData = Array.from({ length: 50 }, (_, i) => ({
+      article_id: i + 1,
+      title: `Old Cached Article ${i + 1}`,
+      bookmark_count: 1,
+    }));
     cacheService.setCache(MOST_BOOKMARKED_CACHE_KEY, oldData, 1);
     await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    const articles = await analyticsService.getMostBookmarkedArticles(1, 5);
-    expect(articles).not.toEqual(oldData);
+    const fresh = await analyticsService.getMostBookmarkedArticles(1, 5);
+    expect(fresh).not.toEqual(oldData.slice(0, 5));
   });
 });


### PR DESCRIPTION
## ✨ Feature: Analytics API with Pagination & Caching

### ✅ Overview
This PR introduces full support for **analytics API routes**, allowing clients to retrieve:

- The most bookmarked articles
- The top users by bookmark count

Both routes now support **pagination** and are backed by **in-memory caching** to improve performance.

---

### 🔧 Key Changes

- `feat:` Add `/api/v1/analytics/most-bookmarked-articles` route
- `feat:` Add `/api/v1/analytics/top-bookmarking-users` route
- `feat:` Implement `analyticsService.js` with caching + pagination (up to 50 items)
- `feat:` Add `analyticsController.js` with shared pagination logic
- `test:` Add full integration test coverage for analytics routes
- `test:` Expand analytics service tests to validate pagination and cache behavior
- `feat:` Add `disableApiFallback` param to prevent real API calls in tests
- `feat:` Add `SKIP_DB_RESET` + `SKIP_DB_TEARDOWN` env flags for faster local test runs
- `chore:` Remove legacy database cleanup logic from `globalSetup.js`
- `fix:` Ensure consistent port usage across test suites

---

### 🧪 Testing Strategy

- Integration tests ensure correct responses, caching, and pagination
- Service-level tests verify caching logic and sliced return values
- Added `npm run test:quick` script to skip reseeding between test runs

