### PR TITLE
62 add middleware to validate numeric url params

### DIFF
--- a/src/middleware/api/errorHandler.js
+++ b/src/middleware/api/errorHandler.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 export default function apiErrorHandler(err, req, res, _next) {
   console.error('API Error:', err.message);
   res.status(500).json({ error: err.message || 'Internal Server Error' });

--- a/src/middleware/validateParam.js
+++ b/src/middleware/validateParam.js
@@ -1,0 +1,9 @@
+export function validateNumericParam(paramName) {
+  return function (req, res, next) {
+    const value = Number(req.params[paramName]);
+    if (isNaN(value)) {
+      return res.status(400).json({ error: `Invalid ${paramName} provided.` });
+    }
+    next();
+  };
+}

--- a/src/routes/api/bookmarkGroupsRoutes.js
+++ b/src/routes/api/bookmarkGroupsRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import bookmarkGroupsController from '../../controllers/bookmarkGroupsController.js';
-import { authMiddleware, validateNumericParam } from '../../middleware';
+import authMiddleware from '../../middleware/authMiddleware.js';
+import { validateNumericParam } from '../../middleware/validateParam.js';
 
 const router = express.Router();
 

--- a/src/routes/api/bookmarkGroupsRoutes.js
+++ b/src/routes/api/bookmarkGroupsRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import bookmarkGroupsController from '../../controllers/bookmarkGroupsController.js';
-import authMiddleware from '../../middleware/authMiddleware.js';
+import { authMiddleware, validateNumericParam } from '../../middleware';
 
 const router = express.Router();
 
@@ -8,28 +8,35 @@ router.get('/', authMiddleware, bookmarkGroupsController.getBookmarkGroups);
 router.get(
   '/:id/articles',
   authMiddleware,
+  validateNumericParam('id'),
   bookmarkGroupsController.getBookmarkGroupWithArticles
 );
 router.post('/', authMiddleware, bookmarkGroupsController.createBookmarkGroup);
 router.patch(
   '/:id',
   authMiddleware,
+  validateNumericParam('id'),
   bookmarkGroupsController.updateBookmarkGroup
 );
 router.delete(
   '/:id',
   authMiddleware,
+  validateNumericParam('id'),
   bookmarkGroupsController.deleteBookmarkGroup
 );
 router.post(
   '/:groupId/bookmarks/:bookmarkId',
   authMiddleware,
+  validateNumericParam('groupId'),
+  validateNumericParam('bookmarkId'),
   bookmarkGroupsController.addBookmarkToGroup
 );
 
 router.delete(
   '/:groupId/bookmarks/:bookmarkId',
   authMiddleware,
+  validateNumericParam('groupId'),
+  validateNumericParam('bookmarkId'),
   bookmarkGroupsController.removeBookmarkFromGroup
 );
 

--- a/src/routes/api/bookmarkRoutes.js
+++ b/src/routes/api/bookmarkRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import bookmarkController from '../../controllers/bookmarksController.js';
-import { authMiddleware, validateNumericParam } from '../../middleware';
+import authMiddleware from '../../middleware/authMiddleware.js';
+import { validateNumericParam } from '../../middleware/validateParam.js';
 
 const router = express.Router();
 

--- a/src/routes/api/bookmarkRoutes.js
+++ b/src/routes/api/bookmarkRoutes.js
@@ -1,11 +1,16 @@
 import express from 'express';
 import bookmarkController from '../../controllers/bookmarksController.js';
-import authMiddleware from '../../middleware/authMiddleware.js';
+import { authMiddleware, validateNumericParam } from '../../middleware';
 
 const router = express.Router();
 
 router.get('/', authMiddleware, bookmarkController.getBookmarks);
 router.post('/', authMiddleware, bookmarkController.createBookmark);
-router.delete('/:id', authMiddleware, bookmarkController.deleteBookmark);
+router.delete(
+  '/:id',
+  authMiddleware,
+  validateNumericParam('id'),
+  bookmarkController.deleteBookmark
+);
 
 export default router;

--- a/src/routes/api/searchRoutes.js
+++ b/src/routes/api/searchRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import queryController from '../../controllers/queryController.js';
-import { validateNumericParam } from '../../middleware';
+import { validateNumericParam } from '../../middleware/validateParam.js';
 
 const router = express.Router();
 

--- a/src/routes/api/searchRoutes.js
+++ b/src/routes/api/searchRoutes.js
@@ -1,9 +1,10 @@
 import express from 'express';
 import queryController from '../../controllers/queryController.js';
+import { validateNumericParam } from '../../middleware';
 
 const router = express.Router();
 
 router.get('/', queryController.getNewsByQuery);
-router.get('/:id', queryController.getArticleById);
+router.get('/:id', validateNumericParam('id'), queryController.getArticleById);
 
 export default router;

--- a/tests/middleware/validateParam.test.js
+++ b/tests/middleware/validateParam.test.js
@@ -1,0 +1,40 @@
+import request from 'supertest';
+import express from 'express';
+import { validateNumericParam } from '../../src/middleware/validateParam.js';
+
+const app = express();
+
+app.get('/test/:id', validateNumericParam('id'), (req, res) => {
+  res.status(200).json({ message: 'Valid ID' });
+});
+
+describe('validateNumericParam middleware', () => {
+  it('allows valid numeric ID as number', async () => {
+    const res = await request(app).get('/test/123');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('Valid ID');
+  });
+
+  it('allows valid numeric ID as string', async () => {
+    const res = await request(app).get('/test/00123');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('Valid ID');
+  });
+
+  it('rejects alphabetic string', async () => {
+    const res = await request(app).get('/test/abc');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/invalid.*id/i);
+  });
+
+  it('rejects alphanumeric string', async () => {
+    const res = await request(app).get('/test/12ab');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/invalid.*id/i);
+  });
+
+  it('rejects missing ID (empty param)', async () => {
+    const res = await request(app).get('/test/');
+    expect(res.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
### ✨ Summary

This PR introduces a reusable `validateNumericParam` middleware function that checks for numeric `:id` values in route params and returns a 400 error for invalid input.

### ✅ Changes Included
- Created `validateNumericParam` in `middleware/validateParam.js`
- Applied to:
  - `/bookmarks/:id`
  - `/bookmark-groups/:id`
  - `/bookmark-groups/:groupId/bookmarks/:bookmarkId`
  - `/articles/:id`
- Added unit tests in `validateParam.test.js` to cover:
  - Valid and invalid numeric inputs
  - Alphanumeric edge cases
- Fixed and normalized `authMiddleware` import style across routes

