### PR TITLE
Test/fill missing coverage

### DIFF
--- a/src/services/analyticsService.js
+++ b/src/services/analyticsService.js
@@ -29,9 +29,7 @@ export async function getMostBookmarkedArticles(page = 1, limit = 10) {
       [MAX_CACHED_ARTICLES]
     );
     const camelCasedResult = camelcaseKeys(result, { deep: true });
-    console.log('CamelCased Result:', camelCasedResult);
     articles = camelCasedResult.rows;
-    console.log('Articles IN SERVICE:', articles);
     cacheService.setCache(MOST_BOOKMARKED_CACHE_KEY, articles, CACHE_TTL);
     logger.info(
       `📌 Cached top ${MAX_CACHED_ARTICLES} most bookmarked articles`

--- a/tests/integration/cache/dbCache.test.js
+++ b/tests/integration/cache/dbCache.test.js
@@ -73,7 +73,6 @@ describe('News Caching (Database Articles)', () => {
 
     const result = await processNewsRequest(1, 6);
     // Cache should now store the DB results
-    console.log('Cache after processNewsRequest:', getCache(CACHE_KEY));
     expect(getSortedUrls(getCache(CACHE_KEY))).toEqual(
       getSortedUrls(mockDBArticles.articles)
     );

--- a/tests/integration/routes/api/bookmarkGroupsRoutes.test.js
+++ b/tests/integration/routes/api/bookmarkGroupsRoutes.test.js
@@ -127,4 +127,45 @@ describe('Bookmark Groups API', () => {
     expect(res.status).toBe(404);
     expect(res.body).toHaveProperty('error');
   });
+
+  it('returns 404 when updating a non-existent group', async () => {
+    const res = await request(app)
+      .patch('/api/v1/bookmark-groups/9999')
+      .set('Authorization', token)
+      .send({ groupName: 'New Name' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+  it('returns 404 when deleting a non-existent group', async () => {
+    const res = await request(app)
+      .delete('/api/v1/bookmark-groups/9999')
+      .set('Authorization', token);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 400 when updating a group without groupName', async () => {
+    const group = await BookmarkGroup.query().insert({
+      userId: user.id,
+      groupName: 'Initial Name',
+    });
+
+    const res = await request(app)
+      .patch(`/api/v1/bookmark-groups/${group.id}`)
+      .set('Authorization', token)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Group name is required/);
+  });
+
+  it('returns 400 when trying to delete without providing groupId', async () => {
+    const res = await request(app)
+      .delete('/api/v1/bookmark-groups/')
+      .set('Authorization', token);
+
+    expect(res.status).toBe(404); // Express will return 404 because route expects :id
+  });
 });


### PR DESCRIPTION
# 🚀 Pull Request: Finalize Bookmark Groups API Test Coverage

## Summary

This PR removes a duplicate sad-path test and finalizes integration test coverage for the Bookmark Groups API routes.

---

## ✨ Changes

- Removed duplicate test for "400 when updating a group without groupName."
- Ensured all critical happy and sad paths are covered:
  - Create a group
  - Prevent duplicate group names
  - Fetch all groups
  - Fetch a single group
  - Update a group name
  - Delete a group
  - Handle 404 for non-existent groups (fetch, update, delete)
  - Handle 400 for missing input fields
  - Handle 404 for missing groupId on delete (Express behavior)

---

## 🧪 Tests

- ✅ All integration tests pass
- ✅ No duplicate tests remaining
- ✅ Coverage for BookmarkGroupsController and routes confirmed

---

# 📋 Notes

- Mocking 500 internal server errors was deferred to prioritize clean integration testing.
- Bookmark group functionality now has full professional coverage for typical user behavior.

